### PR TITLE
Adapted and bug fixed for ubuntu 24.04 due to inconsistent deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ log/
 .vscode/
 
 *.ipynb_checkpoints
+
+# Jetbrain workspaces
+.idea

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ check_status_code $?
 
 echo "[STEAM_ICP] -- [STEAM_ICP] -- building steam icp package"
 cd ${STEAM_ICP_SRC_DIR}
-source /opt/ros/galactic/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 colcon build --symlink-install \
 	--packages-select steam_icp \
 	--cmake-args \

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -53,7 +53,7 @@ ExternalProject_Add(
 	PREFIX Ceres
 
 	GIT_REPOSITORY  https://ceres-solver.googlesource.com/ceres-solver
-	GIT_TAG 2.0.0
+	GIT_TAG 2.2.0
 
 	BUILD_ALWAYS OFF
 	INSTALL_DIR ${EXT_INSTALL_DIR}/Ceres

--- a/steam_icp/simulation/sim.cpp
+++ b/steam_icp/simulation/sim.cpp
@@ -1,16 +1,16 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 
-#include "nav_msgs/msg/odometry.hpp"
-#include "pcl_conversions/pcl_conversions.h"
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-#include "tf2/convert.h"
-#include "tf2_eigen/tf2_eigen.h"
-#include "tf2_ros/static_transform_broadcaster.h"
-#include "tf2_ros/transform_broadcaster.h"
+#include <nav_msgs/msg/odometry.hpp>
+#include <pcl_conversions/pcl_conversions.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2/convert.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 #define PCL_NO_PRECOMPILE
 #include <pcl/io/pcd_io.h>
@@ -18,13 +18,13 @@ namespace fs = std::filesystem;
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include "lgmath.hpp"
-
-#include "steam_icp/point.hpp"
-
 #include <unistd.h>
 #include <random>
 #include <unsupported/Eigen/MatrixFunctions>
+
+#include <lgmath.hpp>
+#include "steam_icp/point.hpp"
+
 
 const uint64_t VLS128_CHANNEL_TDURATION_NS = 2665;
 const uint64_t VLS128_SEQ_TDURATION_NS = 53300;

--- a/steam_icp/src/main.cpp
+++ b/steam_icp/src/main.cpp
@@ -1,16 +1,16 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 
-#include "nav_msgs/msg/odometry.hpp"
-#include "pcl_conversions/pcl_conversions.h"
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-#include "tf2/convert.h"
-#include "tf2_eigen/tf2_eigen.h"
-#include "tf2_ros/static_transform_broadcaster.h"
-#include "tf2_ros/transform_broadcaster.h"
+#include <nav_msgs/msg/odometry.hpp>
+#include <pcl_conversions/pcl_conversions.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2/convert.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 #define PCL_NO_PRECOMPILE
 #include <pcl/io/pcd_io.h>
@@ -18,7 +18,7 @@ namespace fs = std::filesystem;
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include "lgmath.hpp"
+#include <lgmath.hpp>
 
 #include "steam_icp/dataset.hpp"
 #include "steam_icp/odometry.hpp"

--- a/steam_icp/src/odometry/ceres_elastic_icp.cpp
+++ b/steam_icp/src/odometry/ceres_elastic_icp.cpp
@@ -1,11 +1,10 @@
-#include "steam_icp/odometry/ceres_elastic_icp.hpp"
-
 #include <iomanip>
 #include <random>
-
+#include <set>
 #include <ceres/ceres.h>
 #include <glog/logging.h>
 
+#include "steam_icp/odometry/ceres_elastic_icp.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {
@@ -284,7 +283,7 @@ class ICPOptimizationBuilder {
   void AddParameterBlocks(Eigen::Quaterniond &begin_quat, Eigen::Quaterniond &end_quat, Eigen::Vector3d &begin_t,
                           Eigen::Vector3d &end_t) {
     if (parameter_block_set_) throw std::runtime_error{"The parameter block was already set"};
-    auto *parameterization = new ceres::EigenQuaternionParameterization();
+    auto *parameterization = new ceres::EigenQuaternionManifold();
     begin_t_ = &begin_t.x();
     end_t_ = &end_t.x();
     begin_quat_ = &begin_quat.x();

--- a/steam_icp/src/odometry/discrete_lio.cpp
+++ b/steam_icp/src/odometry/discrete_lio.cpp
@@ -1,12 +1,11 @@
-#include "steam_icp/odometry/discrete_lio.hpp"
-
+#include <set>
 #include <iomanip>
 #include <random>
-
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/discrete_lio.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/elastic_icp.cpp
+++ b/steam_icp/src/odometry/elastic_icp.cpp
@@ -1,10 +1,9 @@
-#include "steam_icp/odometry/elastic_icp.hpp"
-
 #include <iomanip>
 #include <random>
-
+#include <set>
 #include <glog/logging.h>
 
+#include "steam_icp/odometry/elastic_icp.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_icp.cpp
+++ b/steam_icp/src/odometry/steam_icp.cpp
@@ -1,12 +1,11 @@
-#include "steam_icp/odometry/steam_icp.hpp"
-
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
+#include <steam.hpp>
 
-#include "steam.hpp"
-
+#include "steam_icp/odometry/steam_icp.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_lio.cpp
+++ b/steam_icp/src/odometry/steam_lio.cpp
@@ -1,12 +1,12 @@
-#include "steam_icp/odometry/steam_lio.hpp"
-
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/steam_lio.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_lo.cpp
+++ b/steam_icp/src/odometry/steam_lo.cpp
@@ -1,12 +1,12 @@
-#include "steam_icp/odometry/steam_lo.hpp"
-
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/steam_lo.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_lo_cv.cpp
+++ b/steam_icp/src/odometry/steam_lo_cv.cpp
@@ -1,12 +1,12 @@
-#include "steam_icp/odometry/steam_lo_cv.hpp"
-
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/steam_lo_cv.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_rio.cpp
+++ b/steam_icp/src/odometry/steam_rio.cpp
@@ -1,12 +1,12 @@
-#include "steam_icp/odometry/steam_lio.hpp"
-
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/steam_lio.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {

--- a/steam_icp/src/odometry/steam_ro.cpp
+++ b/steam_icp/src/odometry/steam_ro.cpp
@@ -1,12 +1,13 @@
-#include "steam_icp/odometry/steam_rio.hpp"
 
 #include <iomanip>
 #include <random>
+#include <set>
 
 #include <glog/logging.h>
 
-#include "steam.hpp"
+#include <steam.hpp>
 
+#include "steam_icp/odometry/steam_rio.hpp"
 #include "steam_icp/utils/stopwatch.hpp"
 
 namespace steam_icp {


### PR DESCRIPTION
Changes:
1. Upgraded Ceres from 2.0.0 to 2.2.0 due to the upgrade of libtbb, where `tbb_stddef.h` was removed. However, `ceres::EigenQuaternionParameterization` will be replaced by "ceres::EigenQuaternionManifold".
2. Added `#include <set>` in some sources as this may cause compiler problem.
3. Corrected some headers, such as `#include <tf2_eigen/tf2_eigen.hpp>`.

 